### PR TITLE
optionally allow options to be passed to request

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,9 @@ var loadDocument = function (url, callback) {
 
 var parse = function(url, callback, opts) {
 
-  loadDocument(url, function (err, body, $,  res) {
+  var req_opts = _.extend({"url": url}, opts)
+
+  loadDocument(req_opts, function (err, body, $,  res) {
     if (!err && body) {
       cleanMicrodata(microdata.toJson(body), function (err, cleanData) {
         if (!err && cleanData) {
@@ -76,12 +78,13 @@ var parse = function(url, callback, opts) {
 
 
 
-module.exports = function (url, callback) {
+module.exports = function (url, callback, opts) {
 
+  opts = opts || {};
 
   parse(url, function (err, data, body) {
     callback(err, data, body);
-  });
+  }, opts);
 
 
 };


### PR DESCRIPTION
Hi Matt,

I hope this suits you. Please let me know if you'd like any changes.

You can test with:

```
var suq = require('suq');

var url = "http://www.nytimes.com/2016/01/31/books/review/the-powers-that-were.html";

suq(url, function (err, json, body) {

    if (!err) {
        console.log('scraped json is:', JSON.stringify(json, null, 2));
        //console.log('html body is', body);
    }

}, { jar:true});
```

It should fail without `, { jar:true}`.

Thanks,
Gary.
